### PR TITLE
Informa remoção da hAPI.getActualThread

### DIFF
--- a/fluig.d.ts
+++ b/fluig.d.ts
@@ -2221,6 +2221,7 @@ type getValuePropertiesInteger =
     | "WKNumProces"
     | "WKVersDef"
     | "WKCardId"
+    | "WKActualThread"
     | "maxResult"
     | "page"
 ;
@@ -2285,6 +2286,7 @@ type getValuePropertiesListRelatedDocumentDto = "WKListRelatedDocument";
  * - WKUserComment: Texto com as observações feitas pelos usuários na atividade corrente
  * - WKUserLocale: Identifica o idioma corrente do usuário
  * - WKVersDef: Versão do processo
+ * - WKActualThread: Thread atual do processo
  * - taskType: Indicador do tipo de tarefas que estão sendo exibidas, “open” tarefas a concluir e “requests” para minhas solicitações.
  * - taskUserId: Código do usuário substituído, em caso de visualização da central como substituto. Nos demais casos retorna o usuário logado.
  * - filter: Filtros utilizados
@@ -2680,6 +2682,9 @@ declare namespace hAPI {
 
     /**
      * Pega o ID da Thread atual
+     *
+     * <strong>ATENÇÃO</strong>
+     * Método removido a partir da versão 1.8.0. Utilize getValue("WKActualThread").
      */
     declare function getActualThread(companyNumber, processNumber, activityNumber): number;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fluig-declaration-type",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fluig-declaration-type",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "ISC",
       "devDependencies": {
         "gulp": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluig-declaration-type",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Fluig decaration types",
   "types": "fluig.d.ts",
   "scripts": {

--- a/src/fluig/global.d.ts
+++ b/src/fluig/global.d.ts
@@ -55,6 +55,7 @@ type getValuePropertiesInteger =
     | "WKNumProces"
     | "WKVersDef"
     | "WKCardId"
+    | "WKActualThread"
     | "maxResult"
     | "page"
 ;
@@ -119,6 +120,7 @@ type getValuePropertiesListRelatedDocumentDto = "WKListRelatedDocument";
  * - WKUserComment: Texto com as observações feitas pelos usuários na atividade corrente
  * - WKUserLocale: Identifica o idioma corrente do usuário
  * - WKVersDef: Versão do processo
+ * - WKActualThread: Thread atual do processo
  * - taskType: Indicador do tipo de tarefas que estão sendo exibidas, “open” tarefas a concluir e “requests” para minhas solicitações.
  * - taskUserId: Código do usuário substituído, em caso de visualização da central como substituto. Nos demais casos retorna o usuário logado.
  * - filter: Filtros utilizados

--- a/src/fluig/hapi.d.ts
+++ b/src/fluig/hapi.d.ts
@@ -241,6 +241,9 @@ declare namespace hAPI {
 
     /**
      * Pega o ID da Thread atual
+     *
+     * <strong>ATENÇÃO</strong>
+     * Método removido a partir da versão 1.8.0. Utilize getValue("WKActualThread").
      */
     declare function getActualThread(companyNumber, processNumber, activityNumber): number;
 


### PR DESCRIPTION
A documentação do Fluig informa que o método hAPI.getActualThread foi removido a partir da versão 1.8.0.

No lugar desse método deve-se utilizar getValue("WKActualThread").